### PR TITLE
fix rootless docker

### DIFF
--- a/inventories/hosts
+++ b/inventories/hosts
@@ -14,5 +14,4 @@ aws_access_key_id=<your access key id>
 aws_secret_access_key=<your secret key >
 s3_url=<your s3 url>
 s3_project_mount_point=<your bucket mount point>
-slack_api_url=https://hooks.slack.com/services/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
-slack_channel=test_alertmanager
+slack_api_url=<your slack url>

--- a/roles/docker-rootless/tasks/main.yml
+++ b/roles/docker-rootless/tasks/main.yml
@@ -20,7 +20,7 @@
   become: false
   ansible.builtin.shell: dockerd-rootless-setuptool.sh install
   args:
-    creates: /home/{{ ansible_user }}/.config/systemd/user/docker.service
+    creates: /opt/.config/systemd/user/docker.service
   when: docker_rootless
 
 - name: 'Set capabilities for rootlesskit'
@@ -39,24 +39,10 @@
     scope: user
   when: docker_rootless and docker_capabilities_update.changed
 
-- name: 'Get current user ID'
-  getent:
-    database: passwd
-    key: '{{ ansible_user }}'
-  when: docker_rootless
-
-- name: 'Add export for path'
-  become: false
-  ansible.builtin.lineinfile:
-    path: /home/{{ ansible_user }}/.bashrc
-    line: export path=/usr/bin:$PATH
-    create: yes
-  when: docker_rootless
-
 - name: 'Add export for DOCKER_HOST'
   become: false
   ansible.builtin.lineinfile:
     path: /home/{{ ansible_user }}/.bashrc
-    line: export DOCKER_HOST=unix:///run/user/{{ getent_passwd[ansible_user][1] }}/docker.sock
+    line: export DOCKER_HOST=unix://${XDG_RUNTIME_DIR}/docker.sock
     create: yes
   when: docker_rootless


### PR DESCRIPTION
Docker is not recommended to run on the HPC, there are a few reasons:
+ Privilege Escalation: If Docker containers are run with elevated privileges (e.g., using the --privileged flag), an attacker who gains control of the container may be able to escalate their privileges to the host system, potentially compromising the entire HPC cluster.
+ Insecure Configurations: Misconfigurations in Docker containers, such as exposing unnecessary ports or mounting sensitive host system directories into the container without proper access controls, can create avenues for attackers to exploit vulnerabilities and gain unauthorized access to the system.
+ Vulnerabilities in Container Images: Docker images, especially those obtained from public repositories, may contain known security vulnerabilities or outdated software with unpatched vulnerabilities. If these vulnerable images are used in HPC environments without proper security assessments, attackers could exploit these vulnerabilities to compromise the system.
+ Container Breakouts: In certain scenarios, attackers may exploit vulnerabilities in Docker itself to escape from the container and gain access to the underlying host system. This could allow them to access sensitive data or execute arbitrary code on the host system, posing a significant security risk to the HPC environment.
+ Resource Exhaustion Attacks: Docker containers have resource limits to prevent them from consuming excessive CPU, memory, or other system resources. However, if these limits are not properly configured, attackers could launch resource exhaustion attacks by consuming all available resources within the container, degrading the performance of other applications running on the HPC cluster.
+ Insufficient Isolation: Docker containers rely on Linux namespaces and control groups (cgroups) for isolation. However, if these mechanisms are bypassed or misconfigured, attackers may be able to access or interfere with other containers or system resources, compromising the overall security of the HPC environment.
Therefore, I only support the singularity as the main container engine in this HPC. Beside, the docker is supported for the sudo group user. For normal user, root-less docker is supported if request.